### PR TITLE
Fix implementation on editing.changes accumulating

### DIFF
--- a/ASP.NET Core/Views/Home/Index.cshtml
+++ b/ASP.NET Core/Views/Home/Index.cshtml
@@ -43,7 +43,9 @@
 <script>
     function validateVisibleRows() {
         const grid = $("#gridContainer").dxDataGrid("instance");
-        const currentChanges = grid.option("editing.changes");
+        const currentChanges = grid.option('editing.changes').filter(c => {
+            return Object.keys(c.data).length > 0;
+        });
         const fakeChanges = grid.getVisibleRows().map(function (row) {
             return { type: "update", key: row.data.ID, data: {} };
         });

--- a/Angular/src/app/app.component.ts
+++ b/Angular/src/app/app.component.ts
@@ -27,10 +27,13 @@ export class AppComponent implements AfterViewChecked {
 
   validateVisibleRows(): void {
     const dataGridInstance = this?.dataGrid?.instance;
+    const currentChanges = (dataGridInstance?.option('editing.changes') as DxDataGridTypes.DataChange[]).filter((c) => {
+      return Object.keys(c.data).length > 0;
+    });
     const fakeChanges = dataGridInstance
       ? dataGridInstance.getVisibleRows().map((row: DxDataGridTypes.Row): DxDataGridTypes.DataChange => ({ type: 'update', key: row.key, data: {} }))
       : [];
-    this.changes = [...this.changes, ...fakeChanges];
+    this.changes = [...currentChanges, ...fakeChanges];
     this.checked = true;
   }
 

--- a/React/src/App.tsx
+++ b/React/src/App.tsx
@@ -17,11 +17,14 @@ function App(): JSX.Element {
 
   const validateVisibleRows = React.useCallback(() => {
     let dataGrid = grid?.current?.instance;
+    const currentChanges = (dataGrid?.option('editing.changes') as DataGridTypes.DataChange[]).filter((c) => {
+      return Object.keys(c.data).length > 0;
+    });
     const fakeChanges = dataGrid
       ? dataGrid.getVisibleRows().map((row: DataGridTypes.Row): DataGridTypes.DataChange => ({ type: 'update', key: row.key, data: {} }))
       : [];
     // alternatively, you can use the DataGrid|option method to set a new changes array
-    setChanges([...changes, ...fakeChanges]);
+    setChanges([...currentChanges, ...fakeChanges]);
     setClicked(true);
   }, [changes]);
 

--- a/Vue/src/components/HomeContent.vue
+++ b/Vue/src/components/HomeContent.vue
@@ -67,6 +67,9 @@ const dataGridRef = ref<DxDataGrid>();
 
 const validateVisibleRows = () => {
   const dataGridInstance = dataGridRef.value?.instance! as dxDataGrid;
+  const currentChanges = (dataGridInstance?.option('editing.changes') as DxDataGridTypes.DataChange[]).filter((c) => {
+      return Object.keys(c.data).length > 0;
+    });
   const fakeChanges = dataGridInstance
     ? dataGridInstance
       .getVisibleRows()
@@ -76,7 +79,7 @@ const validateVisibleRows = () => {
         data: {}
       }))
     : [];
-  changes.value = [...changes.value, ...fakeChanges];
+  changes.value = [...currentChanges, ...fakeChanges];
   clicked.value = true;
 };
 

--- a/jQuery/src/index.js
+++ b/jQuery/src/index.js
@@ -43,7 +43,9 @@ $(() => {
 
 function validateVisibleRows() {
   const grid = $('#gridContainer').dxDataGrid('instance');
-  const currentChanges = grid.option('editing.changes');
+  const currentChanges = grid.option('editing.changes').filter(c => {
+    return Object.keys(c.data).length > 0;
+  });
   const fakeChanges = grid.getVisibleRows().map((row) => ({ type: 'update', key: row.key, data: {} }));
 
   grid.option('editing.changes', [...currentChanges, ...fakeChanges]);


### PR DESCRIPTION
Fixed an issue where the editing.changes array in the Grid was not cleared for newly-added rows that were subsequently deleted. This caused validation to fail as the deleted row's changes remained in the array, even though it was no longer displayed.